### PR TITLE
Output information in JSON format

### DIFF
--- a/python3/pyinotify.py
+++ b/python3/pyinotify.py
@@ -487,14 +487,14 @@ class _Event:
                 value = hex(getattr(self, attr))
             elif isinstance(value, str) and not value:
                 value = "''"
-            s += ' %s%s%s' % (output_format.field_name(attr),
-                              output_format.punctuation('='),
+            s += ' "%s"%s"%s",' % (output_format.field_name(attr),
+                              output_format.punctuation(':'),
                               output_format.field_value(value))
 
-        s = '%s%s%s %s' % (output_format.punctuation('<'),
+        s = '%s"%s":{%s}%s' % (output_format.punctuation('{'),
                            output_format.class_name(self.__class__.__name__),
-                           s,
-                           output_format.punctuation('>'))
+                           re.sub(',$','',s),
+                           output_format.punctuation('}'))
         return s
 
     def __str__(self):
@@ -1525,10 +1525,6 @@ class TornadoAsyncNotifier(Notifier):
         Notifier.stop(self)
 
     def handle_read(self, *args, **kwargs):
-        """
-        See comment in AsyncNotifier.
-
-        """
         self.read_events()
         self.process_events()
         if self.handle_read_callback is not None:


### PR DESCRIPTION
The weird < EVENT attr=value … > format it had was weird and hard to parse, so I replaced it by JSON {"EVENT":{"attr":"value",…}}, which can be piped into jq to get the information you want easily. It's just one of the changes I've made to my local copy and I this was the one I thought was worth sharing.

I suppose it could be backported to the Python 2 version but people still using Python 2 probably don't want anything to change (hey, I can relate).